### PR TITLE
Remove values without a name attribute (fixes: #5).

### DIFF
--- a/bzlib/bugzilla.py
+++ b/bzlib/bugzilla.py
@@ -164,7 +164,7 @@ class Bugzilla(object):
             effect.  If not supplied, no effect.
         """
         field = filter(lambda x: x['name'] == name, self.get_fields())[0]
-        values = field['values']
+        values = [value for value in field['values'] if 'name' in value]
         if omit_empty:
             values = filter(lambda x: x['name'], values)
         value_field = field.get('value_field')


### PR DESCRIPTION
I took a quick look at it and it seems that the bug_status list of dicts has an additional item, that features no name key. See the pretty-print below:

```
$ pp values (bzlib/bugzilla.py:167)
[{'can_change_to': [{'comment_required': False, 'name': 'UNCONFIRMED'},
                    {'comment_required': False, 'name': 'CONFIRMED'},
                    {'comment_required': False, 'name': 'IN_PROGRESS'}],
  'is_open': True,
  'sort_key': 0,
  'sortkey': 0,
  'visibility_values': []},
 {'can_change_to': [{'comment_required': False, 'name': 'CONFIRMED'},
                    {'comment_required': False, 'name': 'IN_PROGRESS'},
                    {'comment_required': False, 'name': 'RESOLVED'}],
  'is_open': True,
  'name': 'UNCONFIRMED',
  'sort_key': 100,
  'sortkey': 100,
  'visibility_values': []},
 {'can_change_to': [{'comment_required': False, 'name': 'IN_PROGRESS'},
                    {'comment_required': False, 'name': 'RESOLVED'}],
  'is_open': True,
  'name': 'CONFIRMED',
  'sort_key': 200,
  'sortkey': 200,
  'visibility_values': []},
 {'can_change_to': [{'comment_required': False, 'name': 'CONFIRMED'},
                    {'comment_required': False, 'name': 'RESOLVED'}],
  'is_open': True,
  'name': 'IN_PROGRESS',
  'sort_key': 300,
  'sortkey': 300,
  'visibility_values': []},
 {'can_change_to': [{'comment_required': False, 'name': 'UNCONFIRMED'},
                    {'comment_required': False, 'name': 'CONFIRMED'},
                    {'comment_required': False, 'name': 'VERIFIED'}],
  'is_open': False,
  'name': 'RESOLVED',
  'sort_key': 400,
  'sortkey': 400,
  'visibility_values': []},
 {'can_change_to': [{'comment_required': False, 'name': 'UNCONFIRMED'},
                    {'comment_required': False, 'name': 'CONFIRMED'}],
  'is_open': False,
  'name': 'VERIFIED',
  'sort_key': 500,
  'sortkey': 500,
  'visibility_values': []}]
```

An easy fix for this is to filter out any item without a name attribute. With this change applied, updating a bug does work again. I also checked the subcommands 'new' and 'fields' and they seem to work as expected. Please review the change and provide feedback.
