### PR TITLE
Fix

### DIFF
--- a/bzlib/bugzilla.py
+++ b/bzlib/bugzilla.py
@@ -166,7 +166,7 @@ class Bugzilla(object):
         field = filter(lambda x: x['name'] == name, self.get_fields())[0]
         values = field['values']
         if omit_empty:
-            values = filter(lambda x: x['name'], values)
+            values = filter(lambda x: 'name' in x, values)
         value_field = field.get('value_field')
         if visible_for and value_field and value_field in visible_for:
             visibility_value = visible_for[value_field]


### PR DESCRIPTION
Hi Fraser,

Stumbled across this problem when trying to update the status of a bug.

Traceback (most recent call last):
  File "/usr/local/bin/bugzilla", line 5, in <module>
    pkg_resources.run_script('bugzillatools==0.5.3.1', 'bugzilla')
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 528, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 1394, in run_script
    execfile(script_filename, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/bugzillatools-0.5.3.1-py2.7.egg/EGG-INFO/scripts/bugzilla", line 83, in <module>
    args.command(args, parser, commands, aliases, ui)()
  File "/usr/local/lib/python2.7/dist-packages/bugzillatools-0.5.3.1-py2.7.egg/bzlib/command.py", line 728, in **call**
    values = self.bz.get_field_values('bug_status')
  File "/usr/local/lib/python2.7/dist-packages/bugzillatools-0.5.3.1-py2.7.egg/bzlib/bugzilla.py", line 166, in get_field_values
    values = filter(lambda x: x['name'], values)
  File "/usr/local/lib/python2.7/dist-packages/bugzillatools-0.5.3.1-py2.7.egg/bzlib/bugzilla.py", line 166, in <lambda>
    values = filter(lambda x: x['name'], values)
KeyError: 'name'
