### PR TITLE
Allow any bug field to be updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ MANIFEST
 *.pyc
 /build/
 /dist/
+*.egg-info

--- a/bzlib/__init__.py
+++ b/bzlib/__init__.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-version_info = (0, 5, 5, 'final', 0)
+version_info = (0, 6, 0, 'final', 0)
 
 version_fmt = '{0}.{1}'
 if version_info[2]:

--- a/bzlib/bug.py
+++ b/bzlib/bug.py
@@ -245,20 +245,8 @@ class Bug(object):
         A wrapper for the RPC ``bug.update`` method that performs some sanity
         checks and flushes cached data as necessary.
         """
-        fields = frozenset([
-            'remaining_time', 'work_time', 'estimated_time', 'deadline',
-            'blocks', 'depends_on',
-            'cc',
-            'comment',
-            'version', 'priority',
-        ])
-        unknowns = kwargs.keys() - fields
-        if unknowns:
-            # unknown arguments
-            raise TypeError('Invalid keyword arguments: {}.'.format(unknowns))
-
         # filter out ``None``s
-        kwargs = {k: v for k, v in kwargs.keys() if v is not None}
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
         # format deadline (YYYY-MM-DD)
         if 'deadline' in kwargs:
             date = kwargs['deadline']


### PR DESCRIPTION
Previously, calls to the the `Bug.update` method would
error out when trying to update a field that wasn't listed.

This was a brittle system that didn't take into account
the fact that some versions of Bugzilla may be modified
and have different fields.
