### PR TITLE
Add a class to handle a list of Bugs

### DIFF
--- a/bzlib/__init__.py
+++ b/bzlib/__init__.py
@@ -15,6 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from . import (
+    bug,
+    bugzilla,
+    config,
+)
+
+__all__ = [
+    'bug',
+    'bugzilla',
+    'config',
+]
+
+
 version_info = (0, 6, 0, 'final', 0)
 
 version_fmt = '{0}.{1}'


### PR DESCRIPTION
Hello!

I noticed something while automating some stuff with Bugzilla, if we want to get or update data from several bugs, it can take quite some time. This comes from the fact that for each bug, a RPC request is sent although the RPC API allows the use of a list of bugs id for some method (mainly get and update).

So I have written a class that can use this feature. This class inherits from a list (functional append, extend, insert, ...), gets data from server lazily and is much much faster when handling a large number of bugs:

```
import timeit
>>> setup = """
... from bzlib.bugzilla import Bugzilla
... from bzlib.config import Config
... from bzlib.bug import Bug, Bugs
...
... bz = Bugzilla.from_config(Config.get_config("~/.bugzillarc"),
...                           server=None, url=None, user=None, password=None)
... """

# 10 Bugs
>>> timeit.timeit(stmt='Bugs(bz, *range(50000,50010)).data', setup=setup, number=1)
1.1943719387054443
>>> timeit.timeit(stmt='for num in range(50000, 50010): Bug(bz, num).data', setup=setup, number=1)
8.836580991744995

# 100 Bugs
>>> timeit.timeit(stmt='Bugs(bz, *range(50000,50100)).data', setup=setup, number=1)
1.8374311923980713
>>> timeit.timeit(stmt='for num in range(50000, 50100): Bug(bz, num).data', setup=setup, number=1)`
67.8080358505249`
```

It is only the base of the class, it is missing some method like the `set_*` of the Bug class but the main is here and the rest can be easily added.

I also added a small patch to make bugzilla, bug and config modules public when importing bzlib alone. They are the most used modules of the library (the rest is for the cli so not really public) so I thought it would be nice to have this.

Thanks!