### PR TITLE
Allow custom SSL context to be used in Bugzilla

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 # NOTE: When we break out the unit tests from the actual python modules this is
 #       going to break this script statement.

--- a/bzlib/bugzilla.py
+++ b/bzlib/bugzilla.py
@@ -102,15 +102,17 @@ class Bugzilla(object):
         return cls(**_server)
 
     def __init__(self, url=None, user=None, password=None,
-                 cookiefile=None, **config):
+                 cookiefile=None, context=None, **config):
         """Create a Bugzilla XML-RPC client.
 
         url         : points to a bugzilla instance (base URL; must end in '/')
         user        : bugzilla username
         password    : bugzilla password
         cookiefile  : filename to optionally store and retrieve cookies from
+        context     : an ssl.SSLContext object used to configure the SSL
+                      settings of the underlying connection. Only applicable to
+                      HTTPS urls.
         """
-
         self._products = None
         self._fields = None
         self._user_cache = {}
@@ -135,7 +137,7 @@ class Bugzilla(object):
         url = url + 'xmlrpc.cgi' if url[-1] == '/' else url + '/xmlrpc.cgi'
         transport = None
         if cookiefile and parsed_url.scheme == "https":
-            transport = SafeCookiesTransport(cookiefile)
+            transport = SafeCookiesTransport(cookiefile, context=context)
         elif cookiefile:
             transport = CookiesTransport(cookiefile)
         # httplib explodes if url is unicode
@@ -144,6 +146,7 @@ class Bugzilla(object):
             use_datetime=True,
             allow_none=True,
             transport=transport,
+            context=context,
         )
 
     def rpc(self, *args, **kwargs):
@@ -244,8 +247,8 @@ class AbstractCookiesTransport:
     cookie file save/load functionality.
     """
 
-    def __init__(self, cookiefile=None):
-        super().__init__()
+    def __init__(self, cookiefile=None, **kwargs):
+        super().__init__(**kwargs)
         self.cookiefile = cookiefile
         self.cookies = SimpleCookie()
         self.load_cookies()


### PR DESCRIPTION
This commit adds support for passing in a custom ssl.SSLContext object to the Bugzilla constructor. This allows users to configure HTTPS connections to Bugzilla and is useful if they need to connect to a Bugzilla server that is, for example, using a self-signed certificate that isn't publicly trusted.