### PR TITLE
Some more py3k fixes.

### DIFF
--- a/bzlib/config.py
+++ b/bzlib/config.py
@@ -40,7 +40,7 @@ def check_section(section):
     raise ConfigError('invalid section: {}'.format(section))
 
 
-class Config(ConfigParser.SafeConfigParser):
+class Config(ConfigParser.ConfigParser):
     _instances = {}
 
     @classmethod
@@ -52,16 +52,16 @@ class Config(ConfigParser.SafeConfigParser):
 
     def __init__(self, path):
         path = os.path.expanduser(path)
-        ConfigParser.SafeConfigParser.__init__(self)
+        ConfigParser.ConfigParser.__init__(self)
         self._path = path
         self.read(self._path)
 
     def write(self):
         with open(self._path, 'w') as fp:
-            ConfigParser.SafeConfigParser.write(self, fp)
+            ConfigParser.ConfigParser.write(self, fp)
 
     def add_section(self, section):
-        ConfigParser.SafeConfigParser.add_section(self, check_section(section))
+        ConfigParser.ConfigParser.add_section(self, check_section(section))
 
 
 NoSectionError = ConfigParser.NoSectionError

--- a/plugin-bzr/__init__.py
+++ b/plugin-bzr/__init__.py
@@ -91,34 +91,36 @@ a bug URL and status in the revision metadata), invoke Bazaar thusly::
 
     bzr commit -m 'fix bug 123' --fixes example:123
 """
+import sys
 
-import bzrlib.api
-import bzrlib.commands
-import bzrlib.trace
+if sys.version_info[0] == 2:
+    import bzrlib.api
+    import bzrlib.commands
+    import bzrlib.trace
 
-import bzlib
+    import bzlib
 
-from . import hooks
+    from . import hooks
 
-# plugin setup
-version_info = bzlib.version_info
+    # plugin setup
+    version_info = bzlib.version_info
 
-COMPATIBLE_BZR_VERSIONS = [
-    (2, 0, 0),
-    (2, 1, 0),
-    (2, 2, 0),
-    (2, 3, 0),
-]
+    COMPATIBLE_BZR_VERSIONS = [
+        (2, 0, 0),
+        (2, 1, 0),
+        (2, 2, 0),
+        (2, 3, 0),
+    ]
 
-bzrlib.api.require_any_api(bzrlib, COMPATIBLE_BZR_VERSIONS)
+    bzrlib.api.require_any_api(bzrlib, COMPATIBLE_BZR_VERSIONS)
 
-if __name__ != 'bzrlib.plugins.bugzillatools':
-    bzrlib.trace.warning(
-        'Not running as bzrlib.plugins.bugzillatools; things may break.')
+    if __name__ != 'bzrlib.plugins.bugzillatools':
+        bzrlib.trace.warning(
+            'Not running as bzrlib.plugins.bugzillatools; things may break.')
 
-# install the get_command hook
-bzrlib.commands.Command.hooks.install_named_hook(
-    'get_command',
-    hooks.get_command_hook,
-    'bugzilla plugin - extend cmd_commit'
-)
+    # install the get_command hook
+    bzrlib.commands.Command.hooks.install_named_hook(
+        'get_command',
+        hooks.get_command_hook,
+        'bugzilla plugin - extend cmd_commit'
+    )


### PR DESCRIPTION
* ConfigParser.SafeConfigParser is dead, and it could be just removed.
* There is no bzr for py3k, so we should avoid plugin/__init__.py to be
  loaded (for automatic tests dicovery)